### PR TITLE
feat: Add Docker setup for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
-FROM ruby:3.1-slim
+# Use the full Ruby 3.4.2 image
+FROM ruby:3.4.2
 
-ENV RACK_ENV=production
+# Set environment variables
+ENV RACK_ENV=production 
+# Or development if preferred for local server logs
 ENV LANG=en_US.UTF-8
 
+# Install OS dependencies (PostgreSQL client libs, build tools)
 RUN apt update && apt install -y \
-  build-essential libpq-dev  \
+  build-essential libpq-dev \
   && rm -rf /var/lib/apt/lists/*
 
-# Install deps
-ADD Gemfile Gemfile.lock ./
+# Update RubyGems & Install/Update Bundler
+# Using latest Bundler 2.x series
+RUN gem update --system && gem install bundler -v '~> 2.5'
 
-RUN bundle install
+# Set working directory inside the container
+WORKDIR /app
 
-ADD . .
+# Copy Gemfile and Gemfile.lock
+COPY Gemfile Gemfile.lock ./
 
-# run server
+# Install gem dependencies using Bundler
+RUN bundle install --jobs $(nproc) --retry 3 
+# Added common optimizations
+
+# Copy the rest of the application code into the container
+COPY . .
+
+# Command to run the application server (uses Bundler)
 CMD bundle exec puma -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 ruby '3.4.2'
 
+
+
 gem 'activerecord'
 gem 'cuba'
 gem 'dalli'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,10 @@
+$LOAD_PATH.unshift('/usr/local/lib/ruby/3.4.0') unless $LOAD_PATH.include?('/usr/local/lib/ruby/3.4.0')
+
+
 require 'active_record'
 require 'yaml'
 require './db'
+require 'csv'
 desc 'Run migrations'
 namespace :db do
   task :migrate do
@@ -17,7 +21,6 @@ namespace :sepomex do
     require 'net/http'
     require 'uri'
     require 'zip'
-    require 'csv'
     require './models/postal_code'
 
     uri = URI.parse('https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx')

--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ This project includes configuration for running locally using Docker and Docker 
 
 1.  **Clone the Repository:**
     ```bash
-    git clone <your-fork-url>
+    git clone https://github.com/AntoSalazar/API-Codigos-Postales.git
     cd API-Codigos-Postales
     ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+# docker-compose.yml
+
+services:
+  db:
+    image: postgres:15 # Use a version known to have 'unaccent' readily available
+    container_name: codigos-postales-db
+    environment:
+      POSTGRES_USER: postgres      # Choose a username
+      POSTGRES_PASSWORD: postgres  # Choose a strong password
+      POSTGRES_DB: api-codigos-postales        # Matches database.yml
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - app-network
+    healthcheck:
+      # Ensure username matches POSTGRES_USER above
+      test: ["CMD-SHELL", "pg_isready -U your_postgres_user -d api-codigos-postales"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build: . # Build from Dockerfile in the current directory
+    container_name: codigos-postales-web
+    command: bundle exec puma -p 3000 -e development
+    volumes:
+      # Optional: Mount code for live changes in development
+      # Note: Might cause issues with permissions or dependencies installed in the image
+      # - .:/app
+      - gem_cache:/usr/local/bundle/gems # Persist gems
+    ports:
+      - "3000:3000" # Map host port 3000 to container port 3000
+    depends_on:
+      db:
+        condition: service_healthy # Wait for DB to be ready
+    networks:
+      - app-network
+    environment:
+      RACK_ENV: development
+      # Construct DATABASE_URL using DB service details
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/api-codigos-postales    
+      VALIDATE_HEADER: X-API-TOKEN             # Example header name
+      VALIDATE_HEADER_VALUE: very-secret-local-token # Example token value
+      # PORT: 3000 # Optional, already default
+
+volumes:
+  postgres_data:
+  gem_cache:
+
+networks:
+  app-network:

--- a/run_sepomex_update.rb
+++ b/run_sepomex_update.rb
@@ -1,0 +1,72 @@
+# run_sepomex_update.rb
+
+# Requires - ensure csv is required early, before potential conflicts
+require 'csv'
+require 'active_record'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'zip'
+require './db'          # Establish DB connection
+require './models/postal_code' # Load the model
+
+
+# --- Start of copied logic from Rake task ---
+uri = URI.parse('https://www.correosdemexico.gob.mx/SSLServicios/ConsultaCP/CodigoPostal_Exportar.aspx')
+
+params = {
+  '__VIEWSTATE' => '/wEPDwUINzcwOTQyOTgPZBYCAgEPZBYCAgEPZBYGAgMPDxYCHgRUZXh0BTrDmmx0aW1hIEFjdHVhbGl6YWNpw7NuIGRlIEluZm9ybWFjacOzbjogRmVicmVybyAyOCBkZSAyMDE5ZGQCBw8QDxYGHg1EYXRhVGV4dEZpZWxkBQNFZG8eDkRhdGFWYWx1ZUZpZWxkBQVJZEVkbx4LXyFEYXRhQm91bmRnZBAVISMtLS0tLS0tLS0tIFQgIG8gIGQgIG8gIHMgLS0tLS0tLS0tLQ5BZ3Vhc2NhbGllbnRlcw9CYWphIENhbGlmb3JuaWETQmFqYSBDYWxpZm9ybmlhIFN1cghDYW1wZWNoZRRDb2FodWlsYSBkZSBaYXJhZ296YQZDb2xpbWEHQ2hpYXBhcwlDaGlodWFodWERQ2l1ZGFkIGRlIE3DqXhpY28HRHVyYW5nbwpHdWFuYWp1YXRvCEd1ZXJyZXJvB0hpZGFsZ28HSmFsaXNjbwdNw6l4aWNvFE1pY2hvYWPDoW4gZGUgT2NhbXBvB01vcmVsb3MHTmF5YXJpdAtOdWV2byBMZcOzbgZPYXhhY2EGUHVlYmxhClF1ZXLDqXRhcm8MUXVpbnRhbmEgUm9vEFNhbiBMdWlzIFBvdG9zw60HU2luYWxvYQZTb25vcmEHVGFiYXNjbwpUYW1hdWxpcGFzCFRsYXhjYWxhH1ZlcmFjcnV6IGRlIElnbmFjaW8gZGUgbGEgTGxhdmUIWXVjYXTDoW4JWmFjYXRlY2FzFSECMDACMDECMDICMDMCMDQCMDUCMDYCMDcCMDgCMDkCMTACMTECMTICMTMCMTQCMTUCMTYCMTcCMTgCMTkCMjACMjECMjICMjMCMjQCMjUCMjYCMjcCMjgCMjkCMzACMzECMzIUKwMhZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZ2dnZGQCHQ88KwALAGQYAQUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgEFC2J0bkRlc2NhcmdhqRZm1BP66KzYxUpp1Ej06LEoJ10=',
+  '__VIEWSTATEGENERATOR' => 'BE1A6D2E',
+  '__EVENTVALIDATION' => '/wEWKALhkeqeAQLG/OLvBgLWk4iCCgLWk4SCCgLWk4CCCgLWk7yCCgLWk7iCCgLWk7SCCgLWk7CCCgLWk6yCCgLWk+iBCgLWk+SBCgLJk4iCCgLJk4SCCgLJk4CCCgLJk7yCCgLJk7iCCgLJk7SCCgLJk7CCCgLJk6yCCgLJk+iBCgLJk+SBCgLIk4iCCgLIk4SCCgLIk4CCCgLIk7yCCgLIk7iCCgLIk7SCCgLIk7CCCgLIk6yCCgLIk+iBCgLIk+SBCgLLk4iCCgLLk4SCCgLLk4CCCgLL+uTWBALa4Za4AgK+qOyRAQLI56b6CwL1/KjtBQShtqSfolZPHREbgq/CaRh97SO2',
+  'cboEdo' => '00',
+  'rblTipo' => 'txt',
+  'btnDescarga.x' => '44',
+  'btnDescarga.y' => '10'
+}
+puts 'Downloading postal codes from SEPOMEX'
+response_post = Net::HTTP.post_form(uri, params)
+
+puts 'Writing Zip'
+File.open('latest.zip', 'w') do |file|
+  file.write response_post.body
+end
+
+puts 'Extracting Zip'
+Zip::File.open('latest.zip') do |zip_file|
+  # Ensure the directory exists if needed, though extracting to current dir is likely fine
+  zip_file.extract('CPdescarga.txt', 'latest.csv') { true } # Overwrite if exists
+end
+
+puts 'Parsing Postal Codes'
+# Use File.read for simplicity if memory allows, otherwise stick with readlines
+csv_text = File.read('latest.csv', encoding: 'ISO-8859-1:UTF-8').lines[1..].join # Skip header line
+csv = CSV.parse(csv_text, col_sep: '|', quote_char: '%', headers: :first_row, return_headers: false) # Don't return headers here
+
+# Removed unnecessary csv.delete calls as CSV.parse with headers: :first_row handles it.
+
+puts 'Inserting new Postal Codes'
+old_logger = ActiveRecord::Base.logger
+ActiveRecord::Base.logger = nil # Temporarily disable verbose SQL logging
+count = 0
+total_rows = 0
+csv.each { |_| total_rows += 1 } # Get total count first for percentage
+# Use find_or_initialize_by + save for potential efficiency, or stick with find_or_create_by
+csv.each do |row|
+  arg = {}
+  row_h = row.to_h
+  arg[:codigo_postal] = row_h['d_codigo']
+  arg[:colonia] = row_h['d_asenta']
+  arg[:municipio] = row_h['D_mnpio']
+  arg[:estado] = row_h['d_estado']
+  PostalCode.find_or_create_by(arg)
+  count += 1
+  print "#{(100 * count) / total_rows}% \r" if total_rows > 0
+end
+ActiveRecord::Base.logger = old_logger # Restore logger
+puts ''
+puts 'Finished Inserting Postal Codes.'
+puts 'Removing TempFiles'
+File.delete('latest.csv')
+File.delete('latest.zip')
+puts 'Done.'
+# --- End of copied logic ---


### PR DESCRIPTION
This PR introduces Docker support for local development of the API-Codigos-Postales project, allowing developers to set up and run the application and its database dependency within containers using Docker Compose.

Summary of Changes:

    Adds a Dockerfile to build a container image for the Ruby application.
    Adds a docker-compose.yml file to orchestrate the application (web) and PostgreSQL (db) services.
    Includes configuration for environment variables (database connection, authentication).
    Adds a workaround script run_sepomex_update.rb for database seeding (see Known Issue below).
    Updates README.md with instructions for Docker-based setup.

How to Use (Summary):

(Full details are in the updated README.md section "Local Development Setup using Docker")

    Ensure Docker and Docker Compose are installed.
    Clone the repository and switch to this branch.
    Build the image: docker compose build
    Start the database: docker compose up -d db
    Run migrations: docker compose run --rm web bundle exec rake db:migrate
    Seed the database: See Known Issue & Workaround section below.
    Start the web server: docker compose up -d web
    Access the API at http://localhost:3000, using authentication headers defined in docker-compose.yml (e.g., X-API-TOKEN: very-secret-local-token).

Known Issue & Workaround: Database Seeding (LoadError: cannot load such file -- csv)

A significant issue was encountered when trying to run the standard database seeding task (bundle exec rake sepomex:update) within the Docker container. This task consistently fails with:

LoadError: cannot load such file -- csv

This error occurs when the Rakefile (or the workaround script when run via bundle exec ruby) attempts to require 'csv', even though:

    The csv library is a default gem included with Ruby 3.4.2.
    Debugging confirmed ruby -e "require 'csv'" works correctly in a plain shell within the container.
    The issue persists despite using the full ruby:3.4.2 Docker image, explicitly adding gem 'csv' to the Gemfile, requiring csv at the top level, updating Bundler, and clearing build caches.

The problem appears to be specific to the execution context created by bundle exec (both rake and ruby), which somehow prevents the standard csv library from being loaded correctly in this environment (Ruby 3.4.2, Bundler ~> 2.5, Docker postgres:15).

Workaround Implementation:

    A script run_sepomex_update.rb containing the logic from the sepomex:update Rake task is included.

    Due to the loading error under bundle exec and subsequent errors loading active_record when run without bundle exec using globally installed gems in testing, seeding the database locally requires a complex workaround, as documented in the README:
        Temporarily modify the Dockerfile to install required gems (pg, activerecord, activesupport, activemodel, rubyzip) globally using gem install instead of bundle install.
        Rebuild the web image without cache.
        Run the script without bundle exec: docker compose run --rm web ruby run_sepomex_update.rb.
        Crucially, revert the Dockerfile back to using bundle install and remove the global gem install line.
        Rebuild the web image again before starting the main application server.

    This workaround is cumbersome but was the only reliable method found to populate the database locally during testing. Further investigation into the root cause of the csv LoadError under bundle exec is needed.


This Docker setup provides a reproducible environment, but the seeding issue requires attention. Any insights into resolving the csv LoadError within the bundle exec context would be greatly appreciated!